### PR TITLE
StepController.Post() - Change 'async void' to 'async Task'

### DIFF
--- a/src/Conductor/Controllers/StepController.cs
+++ b/src/Conductor/Controllers/StepController.cs
@@ -42,7 +42,7 @@ namespace Conductor.Controllers
 
         [HttpPost("{name}")]
         [Authorize(Policy = Policies.Author)]
-        public async void Post(string name)
+        public async Task Post(string name)
         {
             using (var sr = new StreamReader(Request.Body))
             {


### PR DESCRIPTION
If async void throws exception, web server goes down (e.g. duplicate step name)