### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/src/Conductor.Domain/Conductor.Domain.csproj
+++ b/src/Conductor.Domain/Conductor.Domain.csproj
@@ -6,12 +6,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.13" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.13" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="SharpYaml" Version="1.6.5" />
-    <PackageReference Include="StackExchange.Redis" Version="2.0.601" />
-    <PackageReference Include="WorkflowCore" Version="3.2.2" />
+    <PackageReference Include="SharpYaml" Version="1.6.6" />
+    <PackageReference Include="StackExchange.Redis" Version="2.1.0" />
+    <PackageReference Include="WorkflowCore" Version="3.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Conductor.Steps/Conductor.Steps.csproj
+++ b/src/Conductor.Steps/Conductor.Steps.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="RestSharp" Version="106.6.10" />
-    <PackageReference Include="WorkflowCore" Version="3.2.2" />
+    <PackageReference Include="WorkflowCore" Version="3.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Conductor.Storage/Conductor.Storage.csproj
+++ b/src/Conductor.Storage/Conductor.Storage.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.13" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.13" />
     <PackageReference Include="MongoDB.Driver" Version="2.10.0" />
   </ItemGroup>
 

--- a/src/Conductor/Conductor.csproj
+++ b/src/Conductor/Conductor.csproj
@@ -23,12 +23,12 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.13" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.4.10" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
-    <PackageReference Include="WorkflowCore" Version="3.2.2" />
+    <PackageReference Include="WorkflowCore" Version="3.5.0" />
     <PackageReference Include="WorkflowCore.Providers.Redis" Version="3.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Hi@danielgerlag, I found an issue in the Conductor.Domain.csproj:

Packages Microsoft.Extensions.DependencyInjection.Abstractions v3.1.0, Microsoft.Extensions.Logging.Abstractions v3.1.0, SharpYaml v1.6.5, StackExchange.Redis v2.0.601 and WorkflowCore v3.2.2 transitively introduce 90 dependencies into conductor’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/conductor.html)), while Microsoft.Extensions.DependencyInjection.Abstractions v3.1.13, Microsoft.Extensions.Logging.Abstractions v3.1.13, SharpYaml v1.6.6, StackExchange.Redis v2.1.0 and WorkflowCore v3.5.0 can only introduce 52 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/conductor_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose